### PR TITLE
Add driverlib CMakeLists.txt, fix compiler warning

### DIFF
--- a/driverlib/CMakeLists.txt
+++ b/driverlib/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(msp430fr5_driverlib LANGUAGES C)
+
+set(DRIVERLIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/MSP430FR5xx_6xx)
+set(DRIVERLIB_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/MSP430FR5xx_6xx)
+file(GLOB DRIVERLIB_SOURCES ${DRIVERLIB_DIR}/*.c)
+
+add_library(
+    msp430fr5_driverlib
+    ${DRIVERLIB_SOURCES})
+target_include_directories(
+    msp430fr5_driverlib
+    PUBLIC
+    ${DRIVERLIB_INCLUDE})
+target_compile_options(
+    msp430fr5_driverlib
+    PRIVATE
+    # Pointer-integer casting required when working with registers
+    -Wno-int-to-pointer-cast)

--- a/driverlib/MSP430FR5xx_6xx/checksum.c
+++ b/driverlib/MSP430FR5xx_6xx/checksum.c
@@ -26,7 +26,7 @@
  *
  * @note Calling this function erases previous results
  */
-void Setupcrc()
+void Setupcrc(void)
 {
     //CRC_BASE is the starting memory mapped address for the CRC module.
     CRC_setSeed(CRC_BASE, 0xFFFF);
@@ -51,7 +51,7 @@ void Add_crc(uint8_t data)
  *
  * @note Calling this function doesn't reset the register contents
  */
-uint16_t Get_crc()
+uint16_t Get_crc(void)
 {
     return CRC_getResult(CRC_BASE);
 }

--- a/driverlib/MSP430FR5xx_6xx/checksum.h
+++ b/driverlib/MSP430FR5xx_6xx/checksum.h
@@ -17,9 +17,9 @@
 #ifndef CHECKSUM_H_
 #define CHECKSUM_H_
 
-void Setupcrc();
+void Setupcrc(void);
 void Add_crc(uint8_t);
-uint16_t Get_crc();
-uint8_t Check_crc();
+uint16_t Get_crc(void);
+uint8_t Check_crc(uint16_t);
 
 #endif /* CHECKSUM_H_ */

--- a/driverlib/MSP430FR5xx_6xx/cs.c
+++ b/driverlib/MSP430FR5xx_6xx/cs.c
@@ -268,7 +268,7 @@ void CS_initClockSignal (uint8_t selectedClockSignal,
 
             HWREG16(CS_BASE + OFS_CSCTL2) &= ~(SELA_7);
             HWREG16(CS_BASE + OFS_CSCTL2) |= (clockSource);
-            HWREG16(CS_BASE + OFS_CSCTL3) = temp & ~(DIVA0 + DIVA1 + DIVA2) | 
+            HWREG16(CS_BASE + OFS_CSCTL3) = (temp & ~(DIVA0 + DIVA1 + DIVA2)) | 
                                                 clockSourceDivider;
             break;
         case CS_SMCLK:
@@ -286,7 +286,7 @@ void CS_initClockSignal (uint8_t selectedClockSignal,
 
             HWREG16(CS_BASE + OFS_CSCTL2) &= ~(SELS_7);
             HWREG16(CS_BASE + OFS_CSCTL2) |= clockSource;
-            HWREG16(CS_BASE + OFS_CSCTL3) = temp & ~(DIVS0 + DIVS1 + DIVS2) |
+            HWREG16(CS_BASE + OFS_CSCTL3) = (temp & ~(DIVS0 + DIVS1 + DIVS2)) |
                                                 clockSourceDivider;
             break;
         case CS_MCLK:
@@ -301,7 +301,7 @@ void CS_initClockSignal (uint8_t selectedClockSignal,
 
             HWREG16(CS_BASE + OFS_CSCTL2) &= ~(SELM_7);
             HWREG16(CS_BASE + OFS_CSCTL2) |= clockSource;
-            HWREG16(CS_BASE + OFS_CSCTL3) = temp & ~(DIVM0 + DIVM1 + DIVM2) |
+            HWREG16(CS_BASE + OFS_CSCTL3) = (temp & ~(DIVM0 + DIVM1 + DIVM2)) |
                                                 clockSourceDivider;
             break;
     }
@@ -905,8 +905,8 @@ void CS_setDCOFreq(uint16_t dcorsel,
     //Keep overshoot transient within specification by setting clk
     //sources to divide by 4
     //Clear the DIVS & DIVM masks (~0x77) and set both fields to 4 divider
-    HWREG16(CS_BASE + OFS_CSCTL3) = HWREG16(CS_BASE + OFS_CSCTL3) &
-        (~(0x77)) | DIVS1 | DIVM1;
+    HWREG16(CS_BASE + OFS_CSCTL3) = (HWREG16(CS_BASE + OFS_CSCTL3) &
+        (~(0x77))) | DIVS1 | DIVM1;
 
     //Set user's frequency selection for DCO
     HWREG16(CS_BASE + OFS_CSCTL1) = (dcorsel + dcofsel);

--- a/driverlib/MSP430FR5xx_6xx/inc/hw_memmap.h
+++ b/driverlib/MSP430FR5xx_6xx/inc/hw_memmap.h
@@ -29,7 +29,11 @@
 // Macro for enabling assert statements for debugging
 //
 //*****************************************************************************
+// NOTE(jon@auxon.io) - NDEBUG's presence could be controlled by the build
+// system (cmake) 
+#if !defined(NDEBUG)
 #define NDEBUG
+#endif
 
 //*****************************************************************************
 //

--- a/driverlib/MSP430FR5xx_6xx/timer_a.c
+++ b/driverlib/MSP430FR5xx_6xx/timer_a.c
@@ -285,7 +285,7 @@ void Timer_A_setOutputMode(uint16_t baseAddress,
                              uint16_t compareOutputMode)
 {
     uint16_t temp = HWREG16(baseAddress + compareRegister);
-    HWREG16(baseAddress + compareRegister) = temp & ~(OUTMOD_7) | compareOutputMode;
+    HWREG16(baseAddress + compareRegister) = (temp & ~(OUTMOD_7)) | compareOutputMode;
 }
 void Timer_A_clearTimerInterrupt (uint16_t baseAddress)
 {

--- a/driverlib/MSP430FR5xx_6xx/timer_b.c
+++ b/driverlib/MSP430FR5xx_6xx/timer_b.c
@@ -354,7 +354,7 @@ void Timer_B_setOutputMode(uint16_t baseAddress,
                              uint16_t compareOutputMode)
 {
     uint16_t temp = HWREG16(baseAddress + compareRegister);
-    HWREG16(baseAddress + compareRegister) = temp & ~(OUTMOD_7) | compareOutputMode;
+    HWREG16(baseAddress + compareRegister) = (temp & ~(OUTMOD_7)) | compareOutputMode;
 }
 
 


### PR DESCRIPTION
* Adds a basic CMakeLists.txt for the MSP430FR5xx_6xx driverlib
* Fixes a handful of compiler warnings related to strict-prototypes and parentheses