### PR TITLE
Add barectf-platform-pktring submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "barectf-platform-pktring"]
+	path = barectf-platform-pktring
+	url = https://github.com/auxoncorp/barectf-platform-pktring.git

--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@ This repository hosts the library dependencies for Moonranger's MSP code.
 
 Included Libraries:
   - Driverlib : "Software APIs that abstract away the details of the device’s hardware registers"
+  - barectf-platform-pktring : https://github.com/auxoncorp/barectf-platform-pktring


### PR DESCRIPTION
This commit adds the barectf-platform-pktring project as a submodule.
It provides a CTF packet ring buffer platform implementation for barectf, to be conditionally used by the MSP projects.